### PR TITLE
Add fan preset modes with temperature-based speed control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,15 +7,20 @@ Controls the built-in fan (speed 0–100%) and power mode (Always ON / Default)
 via I2C bus. Supports both Classic cases (Pi 3/4) and V3/V5 cases (Pi 5) with
 different I2C protocols.
 
+Fan preset modes (Silent, Default, Performance) provide automatic
+temperature-based speed control with hysteresis when a temperature sensor is
+configured via the options flow.
+
 Installed via HACS as a custom integration. Configured through the HA UI
-(config flow). No YAML configuration.
+(config flow + options flow). No YAML configuration.
 
 ## Technical Context
 
 - **Language/Version**: Python 3.12+
-- **Primary Dependencies**: `homeassistant` (core), `smbus2==0.6.0` (I2C),
-  `voluptuous` (config flow validation, transitive via HA)
-- **Storage**: Home Assistant config entries (managed by HA Core)
+- **Primary Dependencies**: `homeassistant==2026.1.1` (core),
+  `smbus2==0.6.0` (I2C), `voluptuous` (config/options flow validation,
+  transitive via HA)
+- **Storage**: Home Assistant config entries and options (managed by HA Core)
 - **Testing**: N/A (no test suite yet; target framework: `pytest` +
   `pytest-homeassistant-custom-component`)
 - **Target Platform**: Home Assistant OS on Raspberry Pi 3/4/5
@@ -34,7 +39,7 @@ Installed via HACS as a custom integration. Configured through the HA UI
 ├── .devcontainer.json           # VS Code devcontainer config (HA dev env)
 ├── .gitattributes               # Git line-ending and diff settings
 ├── .github/
-│   ├── ISSUE_TEMPLATE/          # Bug report & feature request templates
+│   ├── ISSUE_TEMPLATE/          # Bug report, feature request & testing templates
 │   ├── dependabot.yml           # Dependabot config for deps updates
 │   └── workflows/
 │       ├── lint.yml             # Ruff lint & format CI
@@ -43,13 +48,13 @@ Installed via HACS as a custom integration. Configured through the HA UI
 │   └── configuration.yaml       # HA dev config (devcontainer)
 ├── custom_components/argon_one/ # HA custom integration package
 │   ├── __init__.py              # Entry point: async_setup_entry / async_unload_entry
-│   ├── config_flow.py           # UI config flow: case type selection, I2C check
-│   ├── const.py                 # Constants: domain, I2C addresses, case types
-│   ├── fan.py                   # FanEntity: speed control via I2C
+│   ├── config_flow.py           # Config flow + options flow (case type, temp sensor)
+│   ├── const.py                 # Constants: I2C, case types, preset curves
+│   ├── fan.py                   # FanEntity: speed control, preset modes, sensor tracking
 │   ├── switch.py                # SwitchEntity: Always ON mode (Classic only)
 │   ├── manifest.json            # Integration metadata
 │   └── translations/
-│       └── en.json              # English strings for config flow
+│       └── en.json              # English strings for config & options flows
 ├── scripts/
 │   ├── develop                  # Start HA in dev mode
 │   ├── lint                     # Run ruff format + check
@@ -98,10 +103,19 @@ step. The integration is loaded by HA at runtime.
    `switch.turn_on` / `switch.turn_off`.
 7. **Typed config entry** — use `ArgonOneConfigEntry` (defined in `__init__.py`)
    which is `ConfigEntry[SMBus]`. Access the bus via `entry.runtime_data`.
-8. **Error handling** — on I2C `IOError`, set `_attr_available = False` and
+8. **Error handling** — on I2C `OSError`, set `_attr_available = False` and
    call `self.async_write_ha_state()`. Restore on next successful operation.
-9. **Keep it simple** — project principle is to avoid over-engineering.
-   No GPIO button handling, no preset modes (yet), no complex abstractions.
+9. **Options flow with reload** — `ArgonOneOptionsFlow` extends
+   `OptionsFlowWithReload`. Changing the temperature sensor causes full
+   platform reload; fan reads sensor entity from `entry.options` at init.
+10. **Preset modes require a temperature sensor** — `FanEntityFeature.PRESET_MODE`
+    is only added when `entry.options[CONF_TEMP_SENSOR]` is set. Without a
+    sensor, presets are unavailable.
+11. **Temperature curves and hysteresis** — preset curves are defined in
+    `const.py` → `PRESET_CURVES`. Speed decreases only when temperature drops
+    below (threshold − `HYSTERESIS_CELSIUS`), preventing fan oscillation.
+12. **Keep it simple** — project principle is to avoid over-engineering.
+    No GPIO button handling, no complex abstractions.
 
 ## Code Guidelines
 
@@ -114,6 +128,12 @@ step. The integration is loaded by HA at runtime.
   or data coordinator needed.
 - **DeviceInfo**: Defined inline in each entity's `__init__` with shared
   `identifiers` so HA groups entities under one device.
+- **Sensor tracking**: When a preset mode is active, `fan.py` subscribes to
+  temperature sensor state changes via `async_track_state_change_event` and
+  unsubscribes on preset clear or entity removal.
+- **Config flow + options flow**: `config_flow.py` contains both
+  `ArgonOneConfigFlow` (case type selection, I2C validation) and
+  `ArgonOneOptionsFlow` (temperature sensor selection for presets).
 
 ### Code Quality
 
@@ -122,9 +142,11 @@ step. The integration is loaded by HA at runtime.
 - **Logging**: Use `_LOGGER = logging.getLogger(__name__)` per module.
   Log I2C errors at `error` level, diagnostics at `warning`/`debug`.
 - **Constants**: All magic numbers go in `const.py`. No inline hex values
-  in business logic.
+  in business logic. Temperature curves are data-driven via `PRESET_CURVES`.
 - **HA entity pattern**: Use `_attr_*` class attributes for static properties;
-  use `@property` for dynamic state (`is_on`, `percentage`).
+  use `@property` for dynamic state (`is_on`, `percentage`, `preset_mode`).
+- **Pure logic as static methods**: `_compute_speed` is a `@staticmethod` —
+  easy to test without HA runtime.
 
 ### Testing
 
@@ -133,6 +155,10 @@ step. The integration is loaded by HA at runtime.
   - Mock `smbus2.SMBus` for all I2C operations
   - Test config flow (success, I2C unavailable, I2C device not found,
     already configured)
+  - Test options flow (set/clear temperature sensor)
   - Test fan entity (set speed, turn on/off, I2C error → unavailable)
+  - Test preset modes (`_compute_speed` with various temperatures and
+    hysteresis edge cases)
+  - Test sensor tracking (subscribe/unsubscribe lifecycle, sensor unavailable)
   - Test switch entity (turn on/off, I2C error → unavailable)
   - Test platform loading (Classic → fan + switch; Pi 5 → fan only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Fan preset modes (Silent, Default, Performance) with automatic temperature-based speed control via a configurable HA sensor ([#7](https://github.com/fix-parrot/argon-one/issues/7))
+
 ## [0.1.0] - 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,26 +1,54 @@
 # Argon ONE — Home Assistant Integration
 
-Custom integration for [Argon ONE](https://argon40.com/) Raspberry Pi cases. Controls the built-in fan and power mode via I2C.
+Custom integration for [Argon ONE](https://argon40.com/) Raspberry Pi cases.
+Controls the built-in fan (speed 0–100%) and power mode via I2C bus. Supports
+automatic temperature-based fan control with preset modes (Silent, Default,
+Performance).
 
 ## Supported Cases
 
 | Case | Raspberry Pi | Fan Control | Always ON Mode | Tested |
 |---|---|---|---|---|
-| Argon ONE V1/V2 (Classic) | Pi 3 / Pi 4 | ✅ | ✅ (via I2C) | ❌ [Help wanted](https://github.com/fix-parrot/argon-one/issues) |
+| Argon ONE V1 (Classic) | Pi 3 | ✅ | ✅ (via I2C) | ❌ [Help wanted](https://github.com/fix-parrot/argon-one/issues) |
+| Argon ONE V2 (Classic) | Pi 4 | ✅ | ✅ (via I2C) | ❌ [Help wanted](https://github.com/fix-parrot/argon-one/issues) |
 | Argon ONE V3 | Pi 5 | ✅ | ❌ (hardware jumper) | ✅ |
 | Argon ONE V5 | Pi 5 | ✅ | ❌ (hardware jumper) | ❌ [Help wanted](https://github.com/fix-parrot/argon-one/issues) |
 
-> **Note:** The integration has only been tested on **Argon ONE V3 with Raspberry Pi 5**. If you have a Classic (V1/V2) case or an Argon ONE V5, please check the [open issues](https://github.com/fix-parrot/argon-one/issues) — your help with testing is very welcome!
+> **Note:** The integration has only been tested on **Argon ONE V3 with
+> Raspberry Pi 5**. If you have a Classic (V1/V2) case or an Argon ONE V5,
+> please check the [open issues](https://github.com/fix-parrot/argon-one/issues)
+> — your help with testing is very welcome!
+
+## Key Concepts
+
+- **Fan speed** — direct percentage control (0–100%) of the case fan via I2C.
+  The fan physically does not spin below ~10%.
+- **Preset modes** — automatic temperature-based speed profiles (Silent,
+  Default, Performance). The fan adjusts speed in real time based on a
+  temperature sensor you configure. Requires a temperature sensor entity in
+  Home Assistant (e.g., `sensor.system_monitor_processor_temperature`).
+- **Hysteresis** — when a preset is active, the fan speed only decreases when
+  the temperature drops 2 °C below the threshold, preventing rapid on/off
+  cycling.
+- **Always ON mode** (Classic cases only) — controls the power behavior: when
+  enabled, the Pi starts automatically when power is applied; when disabled, a
+  button press is required. Pi 5 cases use a hardware jumper for this.
+- **I2C** — the communication bus between the Pi and the Argon ONE board. Must
+  be enabled before installing the integration.
 
 ## Prerequisites
 
-**Enable I2C** on your Raspberry Pi before installing the integration. This is the most important step — disabled I2C will prevent the integration from working.
+**Enable I2C** on your Raspberry Pi before installing the integration. Disabled
+I2C will prevent the integration from working.
 
 ### Home Assistant OS
 
-**Recommended:** Install the [HassOS I2C Configurator](https://community.home-assistant.io/t/add-on-hassos-i2c-configurator/264167) add-on and click **Start**. The add-on will automatically enable I2C and reboot your system.
+**Recommended:** Install the [HassOS I2C Configurator](https://community.home-assistant.io/t/add-on-hassos-i2c-configurator/264167)
+add-on and click **Start**. The add-on will automatically enable I2C and
+reboot your system.
 
-**Alternative:** Follow the [official Home Assistant documentation](https://www.home-assistant.io/common-tasks/os) for manual I2C configuration.
+**Alternative:** Follow the [official Home Assistant documentation](https://www.home-assistant.io/common-tasks/os)
+for manual I2C configuration.
 
 After enabling I2C, verify it's available:
 
@@ -40,30 +68,63 @@ ls /dev/i2c-1
 
 ### Manual
 
-Copy the `custom_components/argon_one` folder to your Home Assistant `config/custom_components/` directory and restart.
+Copy the `custom_components/argon_one` folder to your Home Assistant
+`config/custom_components/` directory and restart.
 
 ## Configuration
+
+### Initial setup
 
 1. Go to **Settings** → **Devices & Services** → **Add Integration**
 2. Search for **Argon ONE**
 3. Select your case type (Classic or Pi 5)
-4. Done!
+4. The integration validates the I2C connection and creates the device
+
+### Temperature sensor (optional)
+
+To enable preset modes, configure a temperature sensor:
+
+1. Go to **Settings** → **Devices & Services** → **Argon ONE** → **Configure**
+2. Select a temperature sensor entity
+   (e.g., `sensor.system_monitor_processor_temperature`)
+3. Save — the integration reloads and preset modes become available on the fan
+
+To disable presets, clear the sensor field and save.
 
 ## Entities
 
-The integration creates the following entities under a single **Argon ONE** device:
+The integration creates entities under a single **Argon ONE** device:
 
 | Entity | Entity ID | Case Types | Description |
 |---|---|---|---|
-| Fan | `fan.argon_one_fan` | All | Fan speed control 0–100% |
+| Fan | `fan.argon_one_fan` | All | Fan speed control 0–100% and preset modes |
 | Switch | `switch.argon_one_always_on` | Classic only | Power mode: Always ON / Default |
 
-- **Fan** — controls the case fan speed as a percentage (0–100%). Turning on
-  without specifying speed sets 10% (minimum working speed). The fan physically
-  does not spin below ~10%.
-- **Switch** (Classic only) — toggles the power mode. **ON** = Always ON
-  (Pi starts automatically when power is applied). **OFF** = Default (button
-  press required). Not available on Pi 5 cases — use the hardware jumper instead.
+### Fan
+
+Controls the case fan speed as a percentage (0–100%). Turning on without
+specifying speed sets 10% (minimum working speed).
+
+When a temperature sensor is configured, the fan supports three preset modes:
+
+| Preset | Description |
+|---|---|
+| **Silent** | Fan stays off until 50 °C, ramps gradually, 100% at 75 °C |
+| **Default** | Balanced curve — starts at 50 °C, wider speed range |
+| **Performance** | Aggressive cooling — starts at 47 °C with higher speeds at each step |
+
+Selecting a preset activates automatic control: the fan speed adjusts in real
+time as temperature changes. Setting a manual speed or turning the fan off
+clears the active preset.
+
+### Switch (Classic only)
+
+Toggles the power mode:
+
+- **ON** = Always ON (Pi starts automatically when power is applied)
+- **OFF** = Default (button press required to start)
+
+Not available on Pi 5 cases — use the hardware jumper instead.
 
 ## Services
 
@@ -71,38 +132,36 @@ The integration uses standard Home Assistant services (no custom services):
 
 | Service | Description |
 |---|---|
-| `fan.turn_on` | Turn on the fan (default 10% if no speed specified) |
-| `fan.turn_off` | Turn off the fan |
-| `fan.set_percentage` | Set fan speed 0–100% |
+| `fan.turn_on` | Turn on the fan (default 10%, or specify speed/preset) |
+| `fan.turn_off` | Turn off the fan (clears active preset) |
+| `fan.set_percentage` | Set fan speed 0–100% (clears active preset) |
+| `fan.set_preset_mode` | Activate a preset (silent, default, performance) |
 | `switch.turn_on` | Enable Always ON mode (Classic only) |
 | `switch.turn_off` | Set Default power mode (Classic only) |
 
-## Automation Examples
+## Usage Examples
 
-### Silent Profile — temperature-based fan control
+### Activate a preset mode
 
 ```yaml
-automation:
-  - alias: "Argon ONE Fan - Silent Profile"
-    trigger:
-      - platform: state
-        entity_id: sensor.system_monitor_processor_temperature
-    action:
-      - service: fan.set_percentage
-        target:
-          entity_id: fan.argon_one_fan
-        data:
-          percentage: >
-            {% set temp = states('sensor.system_monitor_processor_temperature') | float %}
-            {% if temp < 40 %} 0
-            {% elif temp < 50 %} 10
-            {% elif temp < 60 %} 25
-            {% elif temp < 70 %} 50
-            {% else %} 100
-            {% endif %}
+service: fan.set_preset_mode
+target:
+  entity_id: fan.argon_one_fan
+data:
+  preset_mode: silent
 ```
 
-### Always ON mode
+### Set manual speed
+
+```yaml
+service: fan.set_percentage
+target:
+  entity_id: fan.argon_one_fan
+data:
+  percentage: 50
+```
+
+### Enable Always ON on startup (Classic only)
 
 ```yaml
 automation:

--- a/custom_components/argon_one/config_flow.py
+++ b/custom_components/argon_one/config_flow.py
@@ -4,14 +4,26 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import voluptuous as vol
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    EntitySelector,
+    EntitySelectorConfig,
+)
 
 from .const import (
     CASE_TYPE_PI5,
     CASE_TYPES,
     CONF_CASE_TYPE,
+    CONF_TEMP_SENSOR,
     DOMAIN,
     I2C_ADDRESS,
     I2C_BUS_NUMBER,
@@ -62,6 +74,14 @@ class ArgonOneConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,  # noqa: ARG004
+    ) -> ArgonOneOptionsFlow:
+        """Create the options flow."""
+        return ArgonOneOptionsFlow()
+
     async def async_step_user(
         self,
         user_input: dict[str, str] | None = None,
@@ -96,3 +116,32 @@ class ArgonOneConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         return self.async_create_entry(title="Argon ONE", data=user_input)
+
+
+class ArgonOneOptionsFlow(OptionsFlowWithReload):
+    """Handle options for Argon ONE."""
+
+    async def async_step_init(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        options_schema = vol.Schema(
+            {
+                vol.Optional(CONF_TEMP_SENSOR): EntitySelector(
+                    EntitySelectorConfig(
+                        device_class="temperature",
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                options_schema, self.config_entry.options
+            ),
+        )

--- a/custom_components/argon_one/const.py
+++ b/custom_components/argon_one/const.py
@@ -25,6 +25,7 @@ CONF_CASE_TYPE = "case_type"
 
 # Fan defaults
 DEFAULT_FAN_SPEED = 10
+HYSTERESIS_CELSIUS = 2.0
 
 # Options keys
 CONF_TEMP_SENSOR = "temperature_sensor"
@@ -40,7 +41,7 @@ PRESET_MODES = [PRESET_SILENT, PRESET_DEFAULT, PRESET_PERFORMANCE]
 # Evaluated top-down; first matching threshold (temp >= threshold) wins.
 # Must be sorted descending by threshold.
 PRESET_CURVES: dict[str, list[tuple[int, int]]] = {
-    PRESET_SILENT: [(75, 100), (70, 75), (65, 50), (58, 25), (50, 10), (0, 0)],
-    PRESET_DEFAULT: [(75, 100), (70, 80), (65, 60), (60, 40), (55, 25), (50, 10), (0, 0)],  # noqa: E501
+    PRESET_SILENT:      [(75, 100), (70, 75), (65, 50), (58, 25), (50, 10), (0, 0)],
+    PRESET_DEFAULT:     [(75, 100), (70, 80), (65, 60), (60, 40), (55, 25), (50, 10), (0, 0)],  # noqa: E501
     PRESET_PERFORMANCE: [(72, 100), (67, 80), (62, 60), (57, 40), (52, 25), (47, 10), (0, 0)],  # noqa: E501
 }

--- a/custom_components/argon_one/const.py
+++ b/custom_components/argon_one/const.py
@@ -25,3 +25,22 @@ CONF_CASE_TYPE = "case_type"
 
 # Fan defaults
 DEFAULT_FAN_SPEED = 10
+
+# Options keys
+CONF_TEMP_SENSOR = "temperature_sensor"
+
+# Fan preset modes
+PRESET_SILENT = "silent"
+PRESET_DEFAULT = "default"
+PRESET_PERFORMANCE = "performance"
+
+PRESET_MODES = [PRESET_SILENT, PRESET_DEFAULT, PRESET_PERFORMANCE]
+
+# Temperature curves: list of (threshold_celsius, fan_speed_percent)
+# Evaluated top-down; first matching threshold (temp >= threshold) wins.
+# Must be sorted descending by threshold.
+PRESET_CURVES: dict[str, list[tuple[int, int]]] = {
+    PRESET_SILENT: [(75, 100), (70, 75), (65, 50), (58, 25), (50, 10), (0, 0)],
+    PRESET_DEFAULT: [(75, 100), (70, 80), (65, 60), (60, 40), (55, 25), (50, 10), (0, 0)],  # noqa: E501
+    PRESET_PERFORMANCE: [(72, 100), (67, 80), (62, 60), (57, 40), (52, 25), (47, 10), (0, 0)],  # noqa: E501
+}

--- a/custom_components/argon_one/const.py
+++ b/custom_components/argon_one/const.py
@@ -41,7 +41,23 @@ PRESET_MODES = [PRESET_SILENT, PRESET_DEFAULT, PRESET_PERFORMANCE]
 # Evaluated top-down; first matching threshold (temp >= threshold) wins.
 # Must be sorted descending by threshold.
 PRESET_CURVES: dict[str, list[tuple[int, int]]] = {
-    PRESET_SILENT:      [(75, 100), (70, 75), (65, 50), (58, 25), (50, 10), (0, 0)],
-    PRESET_DEFAULT:     [(75, 100), (70, 80), (65, 60), (60, 40), (55, 25), (50, 10), (0, 0)],  # noqa: E501
-    PRESET_PERFORMANCE: [(72, 100), (67, 80), (62, 60), (57, 40), (52, 25), (47, 10), (0, 0)],  # noqa: E501
+    PRESET_SILENT: [(75, 100), (70, 75), (65, 50), (58, 25), (50, 10), (0, 0)],
+    PRESET_DEFAULT: [
+        (75, 100),
+        (70, 80),
+        (65, 60),
+        (60, 40),
+        (55, 25),
+        (50, 10),
+        (0, 0),
+    ],
+    PRESET_PERFORMANCE: [
+        (72, 100),
+        (67, 80),
+        (62, 60),
+        (57, 40),
+        (52, 25),
+        (47, 10),
+        (0, 0),
+    ],
 }

--- a/custom_components/argon_one/fan.py
+++ b/custom_components/argon_one/fan.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_TEMP_SENSOR,
     DEFAULT_FAN_SPEED,
     DOMAIN,
+    HYSTERESIS_CELSIUS,
     I2C_ADDRESS,
     PI5_FAN_REGISTER,
     PRESET_CURVES,
@@ -193,18 +194,67 @@ class ArgonOneFan(FanEntity):
             )
             return
 
-        speed = self._compute_speed(self._preset_mode, temp)
+        speed = self._compute_speed(self._preset_mode, temp, self._percentage)
         await self._async_send_speed(speed)
         self._percentage = speed
         self._is_on = speed > 0
 
     @staticmethod
-    def _compute_speed(preset_mode: str, temperature: float) -> int:
-        """Return fan speed for a given preset and temperature."""
-        for threshold, speed in PRESET_CURVES[preset_mode]:
+    def _compute_speed(
+        preset_mode: str,
+        temperature: float,
+        current_speed: int | None = None,
+    ) -> int:
+        """Return fan speed for a preset curve with hysteresis."""
+        curve = PRESET_CURVES[preset_mode]
+
+        new_speed = 0
+        for threshold, speed in curve:
             if temperature >= threshold:
-                return speed
-        return 0
+                new_speed = speed
+                break
+
+        if current_speed is None or new_speed >= current_speed:
+            return new_speed
+
+        current_threshold = None
+        for threshold, speed in curve:
+            if speed == current_speed:
+                current_threshold = threshold
+                break
+
+        if current_threshold is None:
+            _LOGGER.warning(
+                "Current speed not found in curve: "
+                "preset=%s temp=%.2f current_speed=%s fallback_speed=%s",
+                preset_mode,
+                temperature,
+                current_speed,
+                new_speed,
+            )
+            return new_speed
+
+        hold_until = current_threshold - HYSTERESIS_CELSIUS
+
+        if temperature >= hold_until:
+            _LOGGER.debug(
+                "Hold fan speed: "
+                "preset=%s temp=%.2f current_speed=%s hold_until_below=%.2f",
+                preset_mode,
+                temperature,
+                current_speed,
+                hold_until,
+            )
+            return current_speed
+
+        _LOGGER.debug(
+            "Decrease fan speed: preset=%s temp=%.2f old_speed=%s new_speed=%s",
+            preset_mode,
+            temperature,
+            current_speed,
+            new_speed,
+        )
+        return new_speed
 
     # ------------------------------------------------------------------
     # I2C

--- a/custom_components/argon_one/fan.py
+++ b/custom_components/argon_one/fan.py
@@ -6,19 +6,26 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.helpers.event import async_track_state_change_event
 
 if TYPE_CHECKING:
-    from homeassistant.core import HomeAssistant
+    from collections.abc import Callable
+
+    from homeassistant.core import Event, HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
     from . import ArgonOneConfigEntry
 from .const import (
     CASE_TYPE_PI5,
     CONF_CASE_TYPE,
+    CONF_TEMP_SENSOR,
     DEFAULT_FAN_SPEED,
     DOMAIN,
     I2C_ADDRESS,
     PI5_FAN_REGISTER,
+    PRESET_CURVES,
+    PRESET_MODES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,11 +45,6 @@ class ArgonOneFan(FanEntity):
 
     _attr_has_entity_name = True
     _attr_name = "Fan"
-    _attr_supported_features = (
-        FanEntityFeature.SET_SPEED
-        | FanEntityFeature.TURN_ON
-        | FanEntityFeature.TURN_OFF
-    )
 
     def __init__(self, entry: ArgonOneConfigEntry) -> None:
         """Initialize the fan."""
@@ -51,6 +53,22 @@ class ArgonOneFan(FanEntity):
         self._attr_unique_id = f"{entry.entry_id}_fan"
         self._percentage: int | None = None
         self._is_on = False
+        self._preset_mode: str | None = None
+        self._unsub_sensor: Callable[[], None] | None = None
+
+        temp_sensor: str | None = entry.options.get(CONF_TEMP_SENSOR)
+        self._temp_sensor_entity_id = temp_sensor
+
+        features = (
+            FanEntityFeature.SET_SPEED
+            | FanEntityFeature.TURN_ON
+            | FanEntityFeature.TURN_OFF
+        )
+        if temp_sensor:
+            features |= FanEntityFeature.PRESET_MODE
+            self._attr_preset_modes = list(PRESET_MODES)
+        self._attr_supported_features = features
+
         self._attr_device_info = {
             "identifiers": {(DOMAIN, entry.entry_id)},
             "name": "Argon ONE",
@@ -72,28 +90,125 @@ class ArgonOneFan(FanEntity):
         """Return the current speed percentage."""
         return self._percentage
 
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode."""
+        return self._preset_mode
+
     async def async_set_percentage(self, percentage: int) -> None:
         """Set fan speed percentage."""
+        self._clear_preset()
         await self._async_send_speed(percentage)
         self._percentage = percentage
         self._is_on = percentage > 0
 
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the fan preset mode."""
+        if preset_mode not in PRESET_CURVES:
+            msg = f"Invalid preset mode: {preset_mode}"
+            raise ValueError(msg)
+
+        self._preset_mode = preset_mode
+        self._subscribe_sensor()
+        await self._async_apply_preset()
+        self._is_on = True
+
     async def async_turn_on(
         self,
         percentage: int | None = None,
-        preset_mode: str | None = None,  # noqa: ARG002
+        preset_mode: str | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
         """Turn on the fan."""
+        if preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
+            return
         if percentage is None:
             percentage = DEFAULT_FAN_SPEED
         await self.async_set_percentage(percentage)
 
     async def async_turn_off(self, **kwargs: Any) -> None:  # noqa: ARG002
         """Turn off the fan."""
+        self._clear_preset()
         await self._async_send_speed(0)
         self._percentage = 0
         self._is_on = False
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clean up when entity is removed."""
+        self._unsubscribe_sensor()
+
+    # ------------------------------------------------------------------
+    # Preset helpers
+    # ------------------------------------------------------------------
+
+    def _clear_preset(self) -> None:
+        """Clear active preset and unsubscribe from sensor."""
+        if self._preset_mode is not None:
+            self._preset_mode = None
+            self._unsubscribe_sensor()
+
+    def _subscribe_sensor(self) -> None:
+        """Subscribe to temperature sensor state changes."""
+        self._unsubscribe_sensor()
+        if self._temp_sensor_entity_id is None:
+            return
+        self._unsub_sensor = async_track_state_change_event(
+            self.hass,
+            [self._temp_sensor_entity_id],
+            self._on_sensor_state_change,
+        )
+
+    def _unsubscribe_sensor(self) -> None:
+        """Unsubscribe from temperature sensor."""
+        if self._unsub_sensor is not None:
+            self._unsub_sensor()
+            self._unsub_sensor = None
+
+    async def _on_sensor_state_change(self, _event: Event) -> None:
+        """Handle temperature sensor state change."""
+        await self._async_apply_preset()
+        self.async_write_ha_state()
+
+    async def _async_apply_preset(self) -> None:
+        """Compute and send fan speed from current preset and sensor value."""
+        if self._preset_mode is None or self._temp_sensor_entity_id is None:
+            return
+
+        state = self.hass.states.get(self._temp_sensor_entity_id)
+        if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            _LOGGER.warning(
+                "Temperature sensor %s is unavailable, keeping current speed",
+                self._temp_sensor_entity_id,
+            )
+            return
+
+        try:
+            temp = float(state.state)
+        except ValueError:
+            _LOGGER.warning(
+                "Cannot parse temperature from %s: %s",
+                self._temp_sensor_entity_id,
+                state.state,
+            )
+            return
+
+        speed = self._compute_speed(self._preset_mode, temp)
+        await self._async_send_speed(speed)
+        self._percentage = speed
+        self._is_on = speed > 0
+
+    @staticmethod
+    def _compute_speed(preset_mode: str, temperature: float) -> int:
+        """Return fan speed for a given preset and temperature."""
+        for threshold, speed in PRESET_CURVES[preset_mode]:
+            if temperature >= threshold:
+                return speed
+        return 0
+
+    # ------------------------------------------------------------------
+    # I2C
+    # ------------------------------------------------------------------
 
     async def _async_send_speed(self, speed: int) -> None:
         """Send speed command via I2C."""

--- a/custom_components/argon_one/translations/en.json
+++ b/custom_components/argon_one/translations/en.json
@@ -16,5 +16,16 @@
     "abort": {
       "already_configured": "Argon ONE is already configured."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Argon ONE Options",
+        "description": "Select a temperature sensor to enable fan preset modes (Silent, Default, Performance). Leave empty to disable presets.",
+        "data": {
+          "temperature_sensor": "Temperature sensor"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description
Adds built-in fan preset modes (Silent, Default, Performance) with automatic temperature-based speed control. Users can select a HA temperature sensor in integration options, and the fan speed will automatically adjust based on configured temperature curves.

## Changes
- Fan preset modes: Silent, Default, Performance
- Temperature→speed curves with 2°C hysteresis
- Configurable HA temperature sensor via options flow
- Presets available only when sensor is configured

Closes #7