### PR TITLE
Automate release creation

### DIFF
--- a/.github/scripts/build-release-zip
+++ b/.github/scripts/build-release-zip
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Build a release zip archive from custom_components/argon_one.
+#
+# Usage: build-release-zip [output_path]
+# Default output: argon_one.zip in the repository root.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUTPUT="${1:-$REPO_ROOT/argon_one.zip}"
+
+cd "$REPO_ROOT/custom_components"
+zip -r "$OUTPUT" argon_one/ -x '*.pyc' '*__pycache__*' '*.DS_Store'
+
+echo "Built: $OUTPUT"

--- a/.github/scripts/bump-version
+++ b/.github/scripts/bump-version
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Bump version in pyproject.toml, manifest.json, and CHANGELOG.md.
+#
+# Usage: bump-version <patch|minor|major>
+# Output (stdout): CURRENT_VERSION=x.y.z  NEW_VERSION=x.y.z
+#
+# When GITHUB_OUTPUT is set (CI), also writes to $GITHUB_OUTPUT.
+
+set -euo pipefail
+
+BUMP_TYPE="${1:?Usage: bump-version <patch|minor|major>}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PYPROJECT="$REPO_ROOT/pyproject.toml"
+MANIFEST="$REPO_ROOT/custom_components/argon_one/manifest.json"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+REPO_URL="https://github.com/fix-parrot/argon-one"
+
+# --- Read current version ---------------------------------------------------
+
+CURRENT="$(sed -n 's/^version = "\(.*\)"/\1/p' "$PYPROJECT")"
+if [[ ! "$CURRENT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "::error::Invalid current version format: $CURRENT" >&2
+  exit 1
+fi
+
+# --- Compute new version ----------------------------------------------------
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+case "$BUMP_TYPE" in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+  *) echo "::error::Unknown bump type: $BUMP_TYPE" >&2; exit 1 ;;
+esac
+NEW="${MAJOR}.${MINOR}.${PATCH}"
+
+# --- Update pyproject.toml --------------------------------------------------
+
+sed -i.bak "s/^version = \"$CURRENT\"/version = \"$NEW\"/" "$PYPROJECT"
+rm -f "$PYPROJECT.bak"
+
+# --- Update manifest.json ---------------------------------------------------
+
+jq --arg v "$NEW" '.version = $v' "$MANIFEST" > "$MANIFEST.tmp" \
+  && mv "$MANIFEST.tmp" "$MANIFEST"
+
+# --- Update CHANGELOG.md ----------------------------------------------------
+
+TODAY="$(date -u +%Y-%m-%d)"
+
+# Replace ## [Unreleased] with new version header, add new Unreleased above
+sed -i.bak "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$NEW] - $TODAY/" "$CHANGELOG"
+
+# Update [unreleased] comparison link
+sed -i.bak "s|\[unreleased\]: .*|[unreleased]: $REPO_URL/compare/v${NEW}...HEAD|" "$CHANGELOG"
+
+# Add new version comparison link after the [unreleased] link
+sed -i.bak "/^\[unreleased\]:/a\\
+[$NEW]: $REPO_URL/compare/v${CURRENT}...v${NEW}" "$CHANGELOG"
+
+rm -f "$CHANGELOG.bak"
+
+# --- Output ------------------------------------------------------------------
+
+echo "CURRENT_VERSION=$CURRENT"
+echo "NEW_VERSION=$NEW"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "current_version=$CURRENT" >> "$GITHUB_OUTPUT"
+  echo "new_version=$NEW" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/extract-changelog
+++ b/.github/scripts/extract-changelog
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Extract release notes for a specific version from CHANGELOG.md.
+#
+# Usage: extract-changelog <version>
+# Output (stdout): release notes text
+#
+# When GITHUB_OUTPUT is set (CI), also writes a multiline "body" output.
+
+set -euo pipefail
+
+VERSION="${1:?Usage: extract-changelog <version>}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+
+# Extract content between ## [VERSION] and next ## [
+# Also strip reference-style link definitions that appear at the end of the file
+NOTES="$(sed -n "/^## \[$VERSION\]/,/^## \[/{/^## \[/!p}" "$CHANGELOG" | sed '/^\[.*\]:/d')"
+
+if [[ -z "$NOTES" ]]; then
+  NOTES="See [CHANGELOG.md](CHANGELOG.md) for details."
+fi
+
+echo "$NOTES"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "body<<RELEASE_NOTES_EOF"
+    echo "$NOTES"
+    echo "RELEASE_NOTES_EOF"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,90 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Bump version and create PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate unreleased changes exist
+        run: |
+          CONTENT="$(sed -n '/^## \[Unreleased\]/,/^## \[/{/^## \[/!p}' CHANGELOG.md | sed '/^$/d; /^### /d')"
+          if [[ -z "$CONTENT" ]]; then
+            echo "::error::No unreleased changes found in CHANGELOG.md"
+            exit 1
+          fi
+
+      - name: Bump version in project files
+        id: bump
+        run: .github/scripts/bump-version "${{ inputs.bump_type }}"
+
+      - name: Validate tag does not exist
+        run: |
+          if git rev-parse "v${{ steps.bump.outputs.new_version }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ steps.bump.outputs.new_version }} already exists"
+            exit 1
+          fi
+
+      - name: Validate branch does not exist
+        run: |
+          if git ls-remote --exit-code --heads origin "release/v${{ steps.bump.outputs.new_version }}" >/dev/null 2>&1; then
+            echo "::error::Branch release/v${{ steps.bump.outputs.new_version }} already exists"
+            exit 1
+          fi
+
+      - name: Create release branch, commit and push
+        run: |
+          git checkout -b "release/v${{ steps.bump.outputs.new_version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml custom_components/argon_one/manifest.json CHANGELOG.md
+          git commit -m "Bump version to ${{ steps.bump.outputs.new_version }}"
+          git push origin "release/v${{ steps.bump.outputs.new_version }}"
+
+      - name: Extract changelog for PR body
+        id: changelog
+        run: |
+          VERSION="${{ steps.bump.outputs.new_version }}"
+          NOTES="$(.github/scripts/extract-changelog "$VERSION")"
+          {
+            echo "body<<PR_BODY_EOF"
+            echo "## Version bump: ${{ steps.bump.outputs.current_version }} → $VERSION"
+            echo ""
+            echo "**Bump type**: ${{ inputs.bump_type }}"
+            echo ""
+            echo "### Changes"
+            echo "$NOTES"
+            echo "PR_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ steps.changelog.outputs.body }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "release/v${{ steps.bump.outputs.new_version }}" \
+            --title "Release v${{ steps.bump.outputs.new_version }}" \
+            --label "release" \
+            --body "$PR_BODY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid tag format: v$TAG (expected vX.Y.Z)"
+            exit 1
+          fi
+          echo "version=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Verify manifest version matches tag
+        run: |
+          MANIFEST_VERSION="$(jq -r .version custom_components/argon_one/manifest.json)"
+          if [[ "$MANIFEST_VERSION" != "${{ steps.version.outputs.version }}" ]]; then
+            echo "::warning::manifest.json version ($MANIFEST_VERSION) does not match tag (${{ steps.version.outputs.version }})"
+          fi
+
+      - name: Build zip archive
+        run: .github/scripts/build-release-zip
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: .github/scripts/extract-changelog "${{ steps.version.outputs.version }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BODY: ${{ steps.notes.outputs.body }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" \
+            argon_one.zip \
+            --title "$TAG" \
+            --notes "$RELEASE_BODY"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,67 @@
+name: Tag and Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create tag and release
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from manifest
+        id: version
+        run: |
+          VERSION="$(jq -r .version custom_components/argon_one/manifest.json)"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version in manifest.json: $VERSION"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # Note: Tags pushed with GITHUB_TOKEN do not trigger other workflows,
+      # so this will NOT trigger release.yml. The full release is handled here.
+      # release.yml only runs for manually pushed tags.
+      - name: Create and push tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
+
+      - name: Delete release branch
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if git ls-remote --exit-code --heads origin "release/v$VERSION" >/dev/null 2>&1; then
+            git push origin --delete "release/v$VERSION"
+          fi
+
+      - name: Build zip archive
+        run: .github/scripts/build-release-zip
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: .github/scripts/extract-changelog "${{ steps.version.outputs.version }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BODY: ${{ steps.notes.outputs.body }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          gh release create "v$VERSION" \
+            argon_one.zip \
+            --title "v$VERSION" \
+            --notes "$RELEASE_BODY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,16 @@ Installed via HACS as a custom integration. Configured through the HA UI
 │   └── devcontainer.json        # VS Code devcontainer config (HA dev env)
 ├── .github/
 │   ├── ISSUE_TEMPLATE/          # Bug report, feature request & testing templates
+│   ├── scripts/
+│   │   ├── build-release-zip    # Build zip archive from custom_components/
+│   │   ├── bump-version         # Bump version in pyproject.toml, manifest, CHANGELOG
+│   │   └── extract-changelog    # Extract release notes for a given version
 │   ├── dependabot.yml           # Dependabot config for deps updates
 │   └── workflows/
+│       ├── bump.yml             # Version bump workflow (workflow_dispatch)
 │       ├── lint.yml             # Ruff + mypy CI
+│       ├── release.yml          # Build zip + GitHub Release on tag push
+│       ├── tag.yml              # Auto-tag + release on merged bump PR
 │       ├── test.yml             # Pytest + coverage CI
 │       └── validate.yml         # Hassfest + HACS validation CI
 ├── config/
@@ -70,6 +77,7 @@ Installed via HACS as a custom integration. Configured through the HA UI
 │   ├── test_switch.py           # Switch entity tests (on/off, I2C errors)
 │   └── test_init.py             # Platform loading + unload tests
 ├── scripts/
+│   ├── deploy                   # Automated deployment to HA instances
 │   ├── develop                  # Start HA in dev mode (mock I2C)
 │   ├── lint                     # Run ruff format + check via uv
 │   ├── setup                    # uv sync
@@ -103,6 +111,8 @@ step. The integration is loaded by HA at runtime.
 - **Validate manifest**: `python -m script.hassfest --integration-path custom_components/argon_one`
   (requires HA Core dev environment)
 - **HACS validation**: `gh workflow run validate.yml` (or auto on push/PR to main)
+- **Bump version**: `gh workflow run bump.yml -f bump_type=patch` (creates PR)
+- **Release (manual tag)**: `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`
 
 ## Contribution Instructions
 
@@ -166,6 +176,32 @@ step. The integration is loaded by HA at runtime.
   use `@property` for dynamic state (`is_on`, `percentage`, `preset_mode`).
 - **Pure logic as static methods**: `_compute_speed` is a `@staticmethod` —
   easy to test without HA runtime.
+
+### CI/CD Security (GitHub Actions)
+
+- **No `${{ }}` in `run:` for untrusted data**: Never interpolate GitHub
+  context expressions (`github.event.pull_request.title`, `.body`, etc.)
+  directly in `run:` blocks — this is a shell injection vector. Pass through
+  `env:` instead and use `"$VAR"` in the script.
+- **Validated outputs are safe**: Step outputs that passed regex validation
+  (e.g., `^[0-9]+\.[0-9]+\.[0-9]+$`) contain only safe characters and may
+  be used via `${{ }}` in `run:` blocks.
+- **`type: choice` for workflow inputs**: Always use `type: choice` (not
+  `type: string`) for `workflow_dispatch` inputs used in shell commands.
+- **Double-quote all shell variables**: Always `"$VAR"`, never `$VAR`.
+- **Least privilege permissions**: Each workflow declares only the permissions
+  it needs. CI workflows (`lint.yml`, `test.yml`, `validate.yml`) use
+  `permissions: {}`. Release workflows declare `contents: write` only where
+  required.
+- **No `pull_request_target`**: Tag workflow uses `pull_request` trigger
+  (not `pull_request_target`) to avoid running untrusted PR code with write
+  token.
+- **Version source**: Tag workflow extracts version from `manifest.json` on
+  the merged branch, never from PR title or other user-controlled fields.
+- **CI scripts in `.github/scripts/`**: Reusable shell scripts called from
+  workflows. Scripts must never accept unfiltered user-controlled input
+  (PR title, body, etc.) as positional arguments — pass such data only via
+  env variables with double-quoting. All scripts use `set -euo pipefail`.
 
 ### Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fan preset modes (Silent, Default, Performance) with automatic temperature-based speed control via a configurable HA sensor ([#7](https://github.com/fix-parrot/argon-one/issues/7))
 - Complete development workflow overhaul: `uv` package management, 84 tests, CI/CD pipeline, static analysis tooling, mock dev environment, and infrastructure improvements ([#10](https://github.com/fix-parrot/argon-one/issues/10))
+- Automated release pipeline with GitHub Actions and helper scripts ([#11](https://github.com/fix-parrot/argon-one/issues/11))
 
 ## [0.1.0] - 2026-03-21
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -261,6 +261,52 @@ a separate version.
 
 Update the version and document changes in `CHANGELOG.md`.
 
+## Releasing
+
+There are two ways to create a release:
+
+### Path A: Automated (GitHub UI)
+
+1. **Bump version** — go to the GitHub Actions tab, select **Bump Version**,
+   click **Run workflow**, and choose the bump type (`patch`, `minor`, or
+   `major`). The workflow creates a branch `release/vX.Y.Z` with version
+   updates in `pyproject.toml`, `manifest.json`, and `CHANGELOG.md`, then
+   opens a PR titled `Release vX.Y.Z` with the `release` label.
+
+2. **Review & merge** — review the PR (verify version numbers and CHANGELOG
+   content), approve and merge it into `main`.
+
+3. **Tag & release** — after the merge, the **Tag and Release** workflow
+   automatically creates an annotated tag `vX.Y.Z`, deletes the release
+   branch, builds `argon_one.zip`, and publishes a GitHub Release with
+   release notes extracted from CHANGELOG.md.
+
+### Path B: Manual (local bump + tag push)
+
+1. **Bump version locally** — update version in `pyproject.toml`,
+   `manifest.json`, and `CHANGELOG.md` (e.g., via `/dev-bumpversion`).
+
+2. **Commit & push** — commit the changes and push (through a PR if branch
+   protection requires it).
+
+3. **Create and push tag**:
+
+   ```bash
+   git tag -a v0.2.0 -m "Release v0.2.0"
+   git push origin v0.2.0
+   ```
+
+4. **Release** — the **Release** workflow triggers on the tag push, builds
+   `argon_one.zip`, and creates a GitHub Release with release notes.
+
+### Release workflows
+
+| Workflow | File | Trigger |
+|---|---|---|
+| **Bump Version** | `.github/workflows/bump.yml` | `workflow_dispatch` (manual) |
+| **Tag and Release** | `.github/workflows/tag.yml` | Merged PR with `release` label |
+| **Release** | `.github/workflows/release.yml` | Tag push `v*` |
+
 ## CI Pipelines
 
 Three GitHub Actions workflows run automatically on pushes and PRs to `main`:


### PR DESCRIPTION
## Automate release creation

Adds an automated release pipeline.

### New workflows
- **`bump.yml`** — bumps version in `pyproject.toml`, `manifest.json`, and `CHANGELOG.md`; opens a release PR.
- **`tag.yml`** — on merge of a `release`-labelled PR: creates an annotated tag, builds the zip, publishes a GitHub Release.
- **`release.yml`** — same as above, but triggered by a manually pushed `v*` tag.

### New scripts (`.github/scripts/`)
- **`bump-version`** — bumps versions across project files and outputs results to `$GITHUB_OUTPUT`.
- **`build-release-zip`** — packages `custom_components/argon_one/` into `argon_one.zip`.
- **`extract-changelog`** — pulls release notes for a given version from `CHANGELOG.md`.

Closes #11 