### PR TITLE
Restore last known fan state after restart (#4)

### DIFF
--- a/custom_components/argon_one/fan.py
+++ b/custom_components/argon_one/fan.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.fan import FanEntity, FanEntityFeature
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    ATTR_PRESET_MODE,
+    FanEntity,
+    FanEntityFeature,
+)
+from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.restore_state import RestoreEntity
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -42,7 +48,7 @@ async def async_setup_entry(
     async_add_entities([ArgonOneFan(entry)])
 
 
-class ArgonOneFan(FanEntity):
+class ArgonOneFan(FanEntity, RestoreEntity):
     """Argon ONE case fan."""
 
     _attr_has_entity_name = True
@@ -81,6 +87,32 @@ class ArgonOneFan(FanEntity):
                 else "Argon ONE Classic (Pi 3/4)"
             ),
         }
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last known fan state after a restart."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is None:
+            return
+
+        self._is_on = last_state.state == STATE_ON
+        percentage = last_state.attributes.get(ATTR_PERCENTAGE)
+        if isinstance(percentage, int):
+            # Clamp restored speed to a valid range.
+            self._percentage = min(100, max(0, percentage))
+
+        preset_mode = last_state.attributes.get(ATTR_PRESET_MODE)
+        if self._temp_sensor_entity_id is not None and preset_mode in PRESET_CURVES:
+            # Restore the active preset: recompute the speed from the sensor
+            # and re-subscribe so the curve keeps tracking temperature.
+            self._preset_mode = preset_mode
+            self._subscribe_sensor()
+            await self._async_apply_preset()
+            return
+
+        # No preset (or no sensor configured): since the device is write-only,
+        # re-apply the speed so the hardware matches the restored state.
+        if self._is_on and self._percentage is not None:
+            await self._async_send_speed(self._percentage)
 
     @property
     def is_on(self) -> bool:

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -6,7 +6,9 @@ from unittest.mock import MagicMock
 
 from homeassistant.components.fan import FanEntityFeature
 from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.restore_state import StoredState, async_get
+from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.argon_one.const import (
@@ -24,6 +26,17 @@ async def _setup_fan(hass: HomeAssistant, entry: MockConfigEntry) -> None:
     """Set up the integration and wait for platform to load."""
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+
+
+async def _seed_last_state(
+    hass: HomeAssistant, state: str, attributes: dict[str, object]
+) -> None:
+    """Seed a stored state so the fan restores it on setup."""
+    async_get(hass).last_states[FAN_ENTITY_ID] = StoredState(
+        State(FAN_ENTITY_ID, state, attributes),
+        None,
+        dt_util.utcnow(),
+    )
 
 
 async def test_set_percentage(
@@ -351,3 +364,156 @@ async def test_turn_on_with_preset_mode(
     assert state.attributes["preset_mode"] == PRESET_SILENT
     # At 70°C on silent → 75%
     assert state.attributes["percentage"] == 75
+
+
+async def test_restore_last_state_on(
+    hass: HomeAssistant,
+    mock_config_entry_classic: MockConfigEntry,
+    mock_smbus: MagicMock,
+) -> None:
+    """Test that a previously-on fan restores its percentage and re-applies it."""
+    await _seed_last_state(hass, "on", {"percentage": 50})
+    await _setup_fan(hass, mock_config_entry_classic)
+
+    state = hass.states.get(FAN_ENTITY_ID)
+    assert state.state == "on"
+    assert state.attributes["percentage"] == 50
+    mock_smbus.write_byte.assert_called_with(I2C_ADDRESS, 50)
+
+
+async def test_restore_last_state_off(
+    hass: HomeAssistant,
+    mock_config_entry_classic: MockConfigEntry,
+    mock_smbus: MagicMock,
+) -> None:
+    """Test that a previously-off fan stays off without writing to the bus."""
+    await _seed_last_state(hass, "off", {"percentage": 0})
+    await _setup_fan(hass, mock_config_entry_classic)
+
+    state = hass.states.get(FAN_ENTITY_ID)
+    assert state.state == "off"
+    assert state.attributes["percentage"] == 0
+    mock_smbus.write_byte.assert_not_called()
+
+
+async def test_restore_last_state_pi5(
+    hass: HomeAssistant,
+    mock_config_entry_pi5: MockConfigEntry,
+    mock_smbus: MagicMock,
+) -> None:
+    """Test that restore uses the Pi 5 I2C protocol."""
+    await _seed_last_state(hass, "on", {"percentage": 75})
+    await _setup_fan(hass, mock_config_entry_pi5)
+
+    state = hass.states.get(FAN_ENTITY_ID)
+    assert state.state == "on"
+    assert state.attributes["percentage"] == 75
+    mock_smbus.write_byte_data.assert_called_with(I2C_ADDRESS, PI5_FAN_REGISTER, 75)
+    mock_smbus.write_byte.assert_not_called()
+
+
+async def test_restore_clamps_percentage(
+    hass: HomeAssistant,
+    mock_config_entry_classic: MockConfigEntry,
+    mock_smbus: MagicMock,
+) -> None:
+    """Test that restored percentage is clamped to a valid range."""
+    await _seed_last_state(hass, "on", {"percentage": 150})
+    await _setup_fan(hass, mock_config_entry_classic)
+
+    state = hass.states.get(FAN_ENTITY_ID)
+    assert state.state == "on"
+    assert state.attributes["percentage"] == 100
+    mock_smbus.write_byte.assert_called_with(I2C_ADDRESS, 100)
+
+
+async def test_no_stored_state_does_not_write(
+    hass: HomeAssistant,
+    mock_config_entry_classic: MockConfigEntry,
+    mock_smbus: MagicMock,
+) -> None:
+    """Test that fresh setup without a stored state writes nothing to the bus."""
+    await _setup_fan(hass, mock_config_entry_classic)
+
+    mock_smbus.write_byte.assert_not_called()
+
+
+async def test_restore_last_state_preset(
+    hass: HomeAssistant,
+    mock_config_entry_with_sensor: MockConfigEntry,
+    mock_smbus: MagicMock,
+) -> None:
+    """Test that an active preset is restored and re-applied."""
+    hass.states.async_set("sensor.mock_temperature", "65")
+    await _seed_last_state(
+        hass, "on", {"percentage": 60, "preset_mode": PRESET_DEFAULT}
+    )
+    await _setup_fan(hass, mock_config_entry_with_sensor)
+
+    state = hass.states.get(FAN_ENTITY_ID)
+    assert state.state == "on"
+    assert state.attributes["preset_mode"] == PRESET_DEFAULT
+    # 65°C on default curve → 60%
+    assert state.attributes["percentage"] == 60
+    mock_smbus.write_byte.assert_called_with(I2C_ADDRESS, 60)
+
+
+async def test_restore_preset_ignored_without_sensor(
+    hass: HomeAssistant,
+    mock_config_entry_classic: MockConfigEntry,
+    mock_smbus: MagicMock,
+) -> None:
+    """Test that preset is not restored without a configured sensor."""
+    await _seed_last_state(
+        hass, "on", {"percentage": 50, "preset_mode": PRESET_DEFAULT}
+    )
+    await _setup_fan(hass, mock_config_entry_classic)
+
+    state = hass.states.get(FAN_ENTITY_ID)
+    assert state.state == "on"
+    assert state.attributes["preset_mode"] is None
+    assert state.attributes["percentage"] == 50
+    mock_smbus.write_byte.assert_called_with(I2C_ADDRESS, 50)
+
+
+async def test_restore_invalid_preset_falls_back_to_percentage(
+    hass: HomeAssistant,
+    mock_config_entry_with_sensor: MockConfigEntry,
+    mock_smbus: MagicMock,
+) -> None:
+    """Test that an unknown preset falls back to restoring the percentage."""
+    hass.states.async_set("sensor.mock_temperature", "65")
+    await _seed_last_state(
+        hass, "on", {"percentage": 60, "preset_mode": "unknown_preset"}
+    )
+    await _setup_fan(hass, mock_config_entry_with_sensor)
+
+    state = hass.states.get(FAN_ENTITY_ID)
+    assert state.attributes["preset_mode"] is None
+    assert state.attributes["percentage"] == 60
+    mock_smbus.write_byte.assert_called_with(I2C_ADDRESS, 60)
+
+
+async def test_restored_preset_tracks_sensor_changes(
+    hass: HomeAssistant,
+    mock_config_entry_with_sensor: MockConfigEntry,
+    mock_smbus: MagicMock,
+) -> None:
+    """Test that a restored preset keeps tracking temperature changes."""
+    hass.states.async_set("sensor.mock_temperature", "55")
+    await _seed_last_state(
+        hass, "on", {"percentage": 25, "preset_mode": PRESET_DEFAULT}
+    )
+    await _setup_fan(hass, mock_config_entry_with_sensor)
+
+    state = hass.states.get(FAN_ENTITY_ID)
+    assert state.attributes["preset_mode"] == PRESET_DEFAULT
+    # 55°C on default curve → 25%
+    assert state.attributes["percentage"] == 25
+
+    # Temperature rises → preset recalculates speed
+    hass.states.async_set("sensor.mock_temperature", "70")
+    await hass.async_block_till_done()
+
+    state = hass.states.get(FAN_ENTITY_ID)
+    assert state.attributes["percentage"] == 80

--- a/uv.lock
+++ b/uv.lock
@@ -286,7 +286,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "colorlog", specifier = "==6.10.1" },
+    { name = "colorlog", specifier = "==6.12.0" },
     { name = "homeassistant", specifier = "==2026.1.1" },
     { name = "smbus2", specifier = "==0.6.1" },
 ]
@@ -789,14 +789,14 @@ wheels = [
 
 [[package]]
 name = "colorlog"
-version = "6.10.1"
+version = "6.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/55/ba79756cb90c8d69d599d57785398ac87bba7b19c80e87f4e8a562197c93/colorlog-6.12.0.tar.gz", hash = "sha256:2a7924c1dadf18b22a0eb8b06d1c7b01d5341707ec1641eb6fcc4fde0c3e8e5f", size = 18151, upload-time = "2026-07-23T13:40:40.71Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/19/0b6647bf5e331521e55d2b63bfbdc210bd9cd605189273f03614a05f702d/colorlog-6.12.0-py3-none-any.whl", hash = "sha256:30d392604e9110045a2c2aeefc27d7a017abbab63f3a8aee594eac0801df784e", size = 12239, upload-time = "2026-07-23T13:40:39.562Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Persist and restore the last known fan state across Home Assistant restarts.

The fan now implements `RestoreEntity` and, on startup, restores:

- on/off state
- last speed percentage (clamped to a valid 0–100 % range)
- active preset mode (re-subscribes to the temperature sensor and reapplies the speed curve)

Since the device is write-only, the restored speed is re-sent over I2C when the fan was on, so the hardware matches the restored state.

Closes #4