### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-15
+
+### Added
+
+- Brand assets (icon and logo) for Home Assistant and HACS display ([#5](https://github.com/fix-parrot/argon-one/issues/5))
+
+### Fixed
+
+- Restore last known fan state (on/off, speed, preset mode) after Home Assistant restart ([#4](https://github.com/fix-parrot/argon-one/issues/4))
+
 ## [0.2.0] - 2026-03-26
 
 ### Added
@@ -28,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HACS integration support with custom repository installation
 - Temperature-based automation examples in documentation
 
-[unreleased]: https://github.com/fix-parrot/argon-one/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/fix-parrot/argon-one/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/fix-parrot/argon-one/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/fix-parrot/argon-one/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/fix-parrot/argon-one/releases/tag/v0.1.0

--- a/custom_components/argon_one/manifest.json
+++ b/custom_components/argon_one/manifest.json
@@ -13,5 +13,5 @@
     "smbus2==0.6.0"
   ],
   "single_config_entry": true,
-  "version": "0.2.0"
+  "version": "0.3.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "argon-one"
-version = "0.2.0"
+version = "0.3.0"
 description = "Custom Home Assistant integration for Argon ONE Raspberry Pi cases"
 requires-python = ">=3.13.2"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ wheels = [
 
 [[package]]
 name = "argon-one"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
## Version bump: 0.2.0 → 0.3.0

**Bump type**: minor

### Changes
### Added

- Brand assets (icon and logo) for Home Assistant and HACS display ([#5](https://github.com/fix-parrot/argon-one/issues/5))

### Fixed

- Restore last known fan state (on/off, speed, preset mode) after Home Assistant restart ([#4](https://github.com/fix-parrot/argon-one/issues/4))